### PR TITLE
Unlock bracket creation

### DIFF
--- a/src/client/components/App.js
+++ b/src/client/components/App.js
@@ -25,7 +25,7 @@ import { CreateLeague } from "./leagues-flow/CreateLeague";
 ReactGA.initialize("G-GR6LZND73X");
 
 /* Bracket Creation */
-export const BEFORE_OPEN = true;
+export const BEFORE_OPEN = false;
 export const AFTER_START = false;
 
 export default function App() {


### PR DESCRIPTION
Bracket creation is only allowed AFTER Selection Sunday and BEFORE the start of the first game in the tournament. This change sets the `BEFORE_OPEN` flag to `false`, allowing bracket creation after the field is released.

After the change goes through the pipeline, a cache invalidation is required to immediately unlock bracket creation for all users.